### PR TITLE
Magic Trackpad 2 Emulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       JOB_TYPE: BUILD
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           repository: acidanthera/MacKernelSDK
           path: MacKernelSDK
@@ -27,10 +28,6 @@ jobs:
       - name: VoodooInput Bootstrap
         run: |
           src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval "$src" || exit 1
-      - name: Get Version
-        run: |
-          eval $(grep -m 1 "MODULE_VERSION =" VoodooPS2Controller.xcodeproj/project.pbxproj | tr -d ';' | tr -d '\t' | tr -d " ")
-          echo "VPS2_VER=$MODULE_VERSION" >> $GITHUB_ENV
 
       - run: xcodebuild -jobs 1 -configuration Release
       - run: xcodebuild -jobs 1 -configuration Debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
       - name: VoodooInput Bootstrap
         run: |
           src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval "$src" || exit 1
+      - name: Get Version
+        run: |
+          eval $(grep -m 1 "MODULE_VERSION =" VoodooPS2Controller.xcodeproj/project.pbxproj | tr -d ';' | tr -d '\t' | tr -d " ")
+          echo "VPS2_VER=$MODULE_VERSION" >> $GITHUB_ENV
 
       - run: xcodebuild -jobs 1 -configuration Release
       - run: xcodebuild -jobs 1 -configuration Debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       JOB_TYPE: BUILD
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
         with:
           repository: acidanthera/MacKernelSDK
           path: MacKernelSDK
@@ -28,10 +27,6 @@ jobs:
       - name: VoodooInput Bootstrap
         run: |
           src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval "$src" || exit 1
-      - name: Get Version
-        run: |
-          eval $(grep -m 1 "MODULE_VERSION =" VoodooPS2Controller.xcodeproj/project.pbxproj | tr -d ';' | tr -d '\t' | tr -d " ")
-          echo "VPS2_VER=$MODULE_VERSION" >> $GITHUB_ENV
 
       - run: xcodebuild -jobs 1 -configuration Release
       - run: xcodebuild -jobs 1 -configuration Debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,32 +17,36 @@ jobs:
     env:
       JOB_TYPE: BUILD
     steps:
-      - name: Build
-        uses: actions/checkout@v2
-      - run: git clone https://github.com/acidanthera/VoodooInput
-      - run: |
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: acidanthera/MacKernelSDK
+          path: MacKernelSDK
+      - name: CI Bootstrap
+        run: |
+          src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/ocbuild/master/ci-bootstrap.sh) && eval "$src" || exit 1
+      - name: VoodooInput Bootstrap
+        run: |
+          src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval "$src" || exit 1
+      - name: Get Version
+        run: |
           eval $(grep -m 1 "MODULE_VERSION =" VoodooPS2Controller.xcodeproj/project.pbxproj | tr -d ';' | tr -d '\t' | tr -d " ")
-          echo "TAG_VER=$MODULE_VERSION" >> $GITHUB_ENV
-      - run: xcodebuild build -arch x86_64 -scheme VoodooPS2Trackpad -configuration Release -derivedDataPath Build
-      - run: xcodebuild build -arch x86_64 -scheme VoodooPS2Trackpad -configuration Debug -derivedDataPath Build
-      - run: xcodebuild build -arch x86_64 -scheme VoodooPS2Keyboard -configuration Release -derivedDataPath Build
-      - run: xcodebuild build -arch x86_64 -scheme VoodooPS2Keyboard -configuration Debug -derivedDataPath Build
-      - run: xcodebuild build -arch x86_64 -scheme VoodooPS2Controller -configuration Release -derivedDataPath Build
-      - run: xcodebuild build -arch x86_64 -scheme VoodooPS2Controller -configuration Debug -derivedDataPath Build
-      - run: cd Build/Build/Products/Debug && zip -r -X "../VoodooPS2Controller-${TAG_VER}-DEBUG.zip" .
-      - run: cd Build/Build/Products/Release && zip -r -X "../VoodooPS2Controller-${TAG_VER}-RELEASE.zip" .
+          echo "VPS2_VER=$MODULE_VERSION" >> $GITHUB_ENV
+
+      - run: xcodebuild -jobs 1 -configuration Release
+      - run: xcodebuild -jobs 1 -configuration Debug
       
       - name: Upload to Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: Artifacts
-          path: Build/Build/Products/*.zip
+          path: build/*/*.zip
           
       - name: Upload to Release
         if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@e74ff71f7d8a4c4745b560a485cc5fdb9b5b999d
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: Build/Build/Products/*.zip
+          file: build/*/*.zip
           tag: ${{ github.ref }}
           file_glob: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Distribute
 xcuserdata
 xcshareddata
 project.xcworkspace
+/MacKernelSDK
+/VoodooInput

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "VoodooInput"]
-	path = VoodooInput
-	url = https://github.com/acidanthera/VoodooInput.git

--- a/README.md
+++ b/README.md
@@ -1,29 +1,41 @@
-# OS-X-ALPS-DRIVER
+# VoodooPS2-ALPS
 
-This driver is based on 1Revenger1's VoodooPS2 fork, DrHurt's VoodooPS2 repo, Rehabman's VoodooPS2 driver for macOS, Linux 4.7, and bpedman's earlier work. V7 support was ported by coolstarorg.
+This driver has been ported from 1Revenger1's VoodooPS2 fork by DrHurt to support Magic Trackpad 2 emulation.
 
-The aim of this driver is to improve the usability of ALPS TouchPads in macOS.
+The aim of this driver is to improve the usability of ALPS touchpads in macOS and merge the code with acidanthera's VoodooPS2 repo.
 
 ## Driver Features:
 
-- Supports ALPS hardware versions V1-V5, V7, V8
+- Supports ALPS hardware version V7
+    - not supported: V1, V2, V3, V5, V6, V8
 - Supports Mac OS 10.12 to 11.0
-- 1-finger tapping
-- Side (edge) scrolling (Vertical with inertia, and Horizontal)
-- 2-finger tap for right click
-- 2-finger scrolling (vertical and horizontal with inertia)
-- 3-finger gestures (V3+, check the log to find out your hw version)
-- 4-finger gestures (as keyboard shortcut)
-- Pointer acceleration and smoothing
-- Trackstick (movement and scrolling)
+- Look up & data detectors
+- Secondary click (with two fingers, in bottom left corner*, in bottom right corner*)
+- Tap to click
+- Scrolling
+- Zoom in or out
+- Smart zoom
+- Rotate
+- Swipe between pages
+- Swipe between full-screen apps (with three or four fingers)
+- Notification Centre
+- Mission Control (with three or four fingers)
+- App Exposé (with three or four fingers)
+- Dragging with or without drag lock (configured in 'Accessibility'/'Universal Access' prefpane)
+- Three finger drag (configured in 'Accessibility'/'Universal Access' prefpane, may work unreliably**)
+- Launchpad (may work unreliably)
+- Show Desktop (may work unreliably)
+- Screen zoom (configured in 'Accessibility'/'Universal Access' -> Zoom -> Advanced -> Controls -> Use trackpad gesture to zoom)
 
-## Changes:
+## Force Touch
 
-- Touchpad initialization, packet decoding and processing updated Linux 4.7
-- Bitmap processing overhauled. Can now provide coordinates for 2 fingers simultaneously
-- Added new device ids for better compatibility
-- Remove hardcoded variables allowing userspace (plist) settings to apply
-- Painstakingly optimized default settings to provide the best possible experience
-- Improve pointer motion calculation, mode switching,… etc
-- Lots of code cleanups, refactoring
-- Clean up the IOLog
+Force Touch has been disabled for ALPS trackpads as they do not suport width/pressure report. So, the best option is to keep Force Touch disabled.
+
+# Credits
+
+- SkyrilHD (for porting VoodooInput to ALPS)
+- 1Revenger1 (for adding VoodooInput to the code)
+- Acidanthera (for making VoodooInput)
+- DrHurt (for the main code)
+- Linux
+- usr-sse2 (for the huge work he did for Synaptics)

--- a/VoodooPS2Controller.xcodeproj/project.pbxproj
+++ b/VoodooPS2Controller.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		719386E426E17E8600467AB9 /* libkmod.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 719386E326E17E8600467AB9 /* libkmod.a */; };
+		71A0A5CA26E1493300530E0F /* VoodooInputTransducer.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A0A5C626E1493300530E0F /* VoodooInputTransducer.h */; };
+		71A0A5CB26E1493300530E0F /* VoodooInputEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A0A5C726E1493300530E0F /* VoodooInputEvent.h */; };
+		71A0A5CC26E1493300530E0F /* VoodooInputMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A0A5C826E1493300530E0F /* VoodooInputMessages.h */; };
+		71A0A5CD26E1493300530E0F /* MultitouchHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A0A5C926E1493300530E0F /* MultitouchHelpers.h */; };
 		840F104A16EFE42600E8C116 /* ApplePS2Device.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 840F104916EFE42600E8C116 /* ApplePS2Device.cpp */; };
 		84167820161B55B2002C60E6 /* VoodooPS2Controller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8416781F161B55B2002C60E6 /* VoodooPS2Controller.cpp */; };
 		84167836161B5613002C60E6 /* VoodooPS2Keyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84167835161B5613002C60E6 /* VoodooPS2Keyboard.cpp */; };
@@ -24,7 +29,30 @@
 		84EB0AE516F0AD9600016108 /* ApplePS2MouseDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84833FA0161B627D00845294 /* ApplePS2MouseDevice.cpp */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		71CC94A226E81FFA00BEB0AC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84167808161B55B2002C60E6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8416782C161B5613002C60E6;
+			remoteInfo = VoodooPS2Keyboard;
+		};
+		71CC94A426E81FFA00BEB0AC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84167808161B55B2002C60E6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 84167854161B56C4002C60E6;
+			remoteInfo = VoodooPS2Trackpad;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		719386E326E17E8600467AB9 /* libkmod.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libkmod.a; path = MacKernelSDK/Library/x86_64/libkmod.a; sourceTree = "<group>"; };
+		71A0A5C626E1493300530E0F /* VoodooInputTransducer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VoodooInputTransducer.h; path = VoodooInput/Debug/VoodooInput.kext/Contents/Resources/VoodooInputMultitouch/VoodooInputTransducer.h; sourceTree = SOURCE_ROOT; };
+		71A0A5C726E1493300530E0F /* VoodooInputEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VoodooInputEvent.h; path = VoodooInput/Debug/VoodooInput.kext/Contents/Resources/VoodooInputMultitouch/VoodooInputEvent.h; sourceTree = SOURCE_ROOT; };
+		71A0A5C826E1493300530E0F /* VoodooInputMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VoodooInputMessages.h; path = VoodooInput/Debug/VoodooInput.kext/Contents/Resources/VoodooInputMultitouch/VoodooInputMessages.h; sourceTree = SOURCE_ROOT; };
+		71A0A5C926E1493300530E0F /* MultitouchHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MultitouchHelpers.h; path = VoodooInput/Debug/VoodooInput.kext/Contents/Resources/VoodooInputMultitouch/MultitouchHelpers.h; sourceTree = SOURCE_ROOT; };
+		71C22F1D26E183A100FE8589 /* VoodooPS2Common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VoodooPS2Common.h; sourceTree = "<group>"; };
 		8404565C161E3AAF00D74D7F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		84045662161E3AD800D74D7F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		84045665161E3AF900D74D7F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -66,6 +94,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				719386E426E17E8600467AB9 /* libkmod.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -86,9 +115,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7197CFC326E0DBE8005B9F34 /* VoodooInput Headers */ = {
+			isa = PBXGroup;
+			children = (
+				71A0A5C926E1493300530E0F /* MultitouchHelpers.h */,
+				71A0A5C726E1493300530E0F /* VoodooInputEvent.h */,
+				71A0A5C826E1493300530E0F /* VoodooInputMessages.h */,
+				71A0A5C626E1493300530E0F /* VoodooInputTransducer.h */,
+			);
+			path = "VoodooInput Headers";
+			sourceTree = "<group>";
+		};
 		84167806161B55B2002C60E6 = {
 			isa = PBXGroup;
 			children = (
+				719386E326E17E8600467AB9 /* libkmod.a */,
 				84167818161B55B2002C60E6 /* VoodooPS2Controller */,
 				8416782E161B5613002C60E6 /* VoodooPS2Keyboard */,
 				84167856161B56C4002C60E6 /* VoodooPS2Trackpad */,
@@ -172,9 +213,11 @@
 		84167856161B56C4002C60E6 /* VoodooPS2Trackpad */ = {
 			isa = PBXGroup;
 			children = (
+				7197CFC326E0DBE8005B9F34 /* VoodooInput Headers */,
 				84833FAC161B62A900845294 /* alps.h */,
 				84833FAB161B62A900845294 /* alps.cpp */,
 				84167857161B56C4002C60E6 /* Supporting Files */,
+				71C22F1D26E183A100FE8589 /* VoodooPS2Common.h */,
 			);
 			path = VoodooPS2Trackpad;
 			sourceTree = "<group>";
@@ -226,7 +269,11 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				71A0A5CB26E1493300530E0F /* VoodooInputEvent.h in Headers */,
+				71A0A5CD26E1493300530E0F /* MultitouchHelpers.h in Headers */,
 				84833FB2161B62A900845294 /* alps.h in Headers */,
+				71A0A5CA26E1493300530E0F /* VoodooInputTransducer.h in Headers */,
+				71A0A5CC26E1493300530E0F /* VoodooInputMessages.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -242,10 +289,13 @@
 				8416780F161B55B2002C60E6 /* Headers */,
 				84167810161B55B2002C60E6 /* Resources */,
 				84167811161B55B2002C60E6 /* Rez */,
+				71CC94A726E8215C00BEB0AC /* Archive */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				71CC94A326E81FFA00BEB0AC /* PBXTargetDependency */,
+				71CC94A526E81FFA00BEB0AC /* PBXTargetDependency */,
 			);
 			name = VoodooPS2Controller;
 			productName = VoodooPS2Controller;
@@ -273,6 +323,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 84167860161B56C4002C60E6 /* Build configuration list for PBXNativeTarget "VoodooPS2Trackpad" */;
 			buildPhases = (
+				71A0A5C526E1440600530E0F /* Bootstrap VoodooInput */,
 				8416784F161B56C4002C60E6 /* Sources */,
 				84167850161B56C4002C60E6 /* Frameworks */,
 				84167851161B56C4002C60E6 /* Headers */,
@@ -298,11 +349,11 @@
 			};
 			buildConfigurationList = 8416780B161B55B2002C60E6 /* Build configuration list for PBXProject "VoodooPS2Controller" */;
 			compatibilityVersion = "Xcode 8.0";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
-				English,
+				Base,
 			);
 			mainGroup = 84167806161B55B2002C60E6;
 			projectDirPath = "";
@@ -363,6 +414,45 @@
 		};
 /* End PBXRezBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		71A0A5C526E1440600530E0F /* Bootstrap VoodooInput */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Bootstrap VoodooInput";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "if [ ! -f \"${PROJECT_DIR}/VoodooInput/Debug/VoodooInput.kext/Contents/Resources/VoodooInputMultitouch/VoodooInputEvent.h\" ]; then\n  cd \"${PROJECT_DIR}\"\n  rm -rf VoodooInput\n  src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval \"$src\" || exit 1\nfi\n";
+		};
+		71CC94A726E8215C00BEB0AC /* Archive */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Archive;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cd \"${TARGET_BUILD_DIR}\"\nrm -rf \"${FULL_PRODUCT_NAME}/Contents/PlugIns/VoodooInput.kext\"\nmkdir -p \"${FULL_PRODUCT_NAME}/Contents/PlugIns\"\ncp -r \"${PROJECT_DIR}/VoodooInput/${CONFIGURATION}\"/* \"${FULL_PRODUCT_NAME}/Contents/PlugIns/\"\ndist=(\"$FULL_PRODUCT_NAME\")\nif [ -d \"$DWARF_DSYM_FILE_NAME\" ]; then\n  rm -rf dSYM\n  mkdir dSYM\n  mv \"$DWARF_DSYM_FILE_NAME\" dSYM/\n  find ${FULL_PRODUCT_NAME} -name *.dSYM -exec mv {} dSYM/ \\;\n  dist+=(dSYM);\nfi\n\narchive=\"${PRODUCT_NAME}-${MODULE_VERSION}-$(echo $CONFIGURATION | tr /a-z/ /A-Z/).zip\"\nrm -rf *.zip\nzip -qry -FS \"${archive}\" \"${dist[@]}\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		8416780D161B55B2002C60E6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -393,6 +483,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		71CC94A326E81FFA00BEB0AC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8416782C161B5613002C60E6 /* VoodooPS2Keyboard */;
+			targetProxy = 71CC94A226E81FFA00BEB0AC /* PBXContainerItemProxy */;
+		};
+		71CC94A526E81FFA00BEB0AC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 84167854161B56C4002C60E6 /* VoodooPS2Trackpad */;
+			targetProxy = 71CC94A426E81FFA00BEB0AC /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		8404565B161E3AAF00D74D7F /* InfoPlist.strings */ = {
@@ -426,6 +529,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_USE_OPTIMIZATION_PROFILE = NO;
 				CLANG_WARN_BOOL_CONVERSION = YES;
@@ -437,12 +541,13 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CURRENT_PROJECT_VERSION = 6.0.0;
-				DEBUG_INFORMATION_FORMAT = dwarf;
+				CURRENT_PROJECT_VERSION = "";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_LOCATION = NO;
 				DEPLOYMENT_POSTPROCESSING = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/MacKernelSDK/Headers";
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = fast;
@@ -459,10 +564,16 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/MacKernelSDK/Headers";
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/universal",
+				);
 				LLVM_LTO = YES_THIN;
 				"LLVM_LTO[arch=x86_64]" = YES_THIN;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MODULE_VERSION = 1.0.1;
+				MODULE_NAME = "";
+				MODULE_VERSION = 1.0.3;
 				ONLY_ACTIVE_ARCH = YES;
 				"OTHER_LDFLAGS[arch=x86_64]" = "-dead_strip";
 				PRODUCT_NAME = VoodooPS2Controller;
@@ -474,6 +585,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_USE_OPTIMIZATION_PROFILE = NO;
 				CLANG_WARN_BOOL_CONVERSION = YES;
@@ -485,11 +597,12 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CURRENT_PROJECT_VERSION = 6.0.0;
-				DEBUG_INFORMATION_FORMAT = dwarf;
+				CURRENT_PROJECT_VERSION = "";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_POSTPROCESSING = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = NO;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/MacKernelSDK/Headers";
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = fast;
@@ -500,10 +613,16 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/MacKernelSDK/Headers";
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/universal",
+				);
 				LLVM_LTO = YES_THIN;
 				"LLVM_LTO[arch=x86_64]" = YES_THIN;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MODULE_VERSION = 1.0.1;
+				MODULE_NAME = "";
+				MODULE_VERSION = 1.0.3;
 				ONLY_ACTIVE_ARCH = YES;
 				"OTHER_LDFLAGS[arch=x86_64]" = "-dead_strip";
 				PRODUCT_NAME = VoodooPS2Controller;
@@ -514,14 +633,19 @@
 		84167825161B55B2002C60E6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.0.0;
+				CURRENT_PROJECT_VERSION = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				INFOPLIST_FILE = "VoodooPS2Controller/VoodooPS2Controller-Info.plist";
-				MARKETING_VERSION = 1.0.0;
-				MODULE_NAME = com.rehabman.driver.VoodooPS2Controller;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/universal",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
+				);
+				MODULE_NAME = com.skyrilhd.VoodooPS2Controller;
 				OTHER_CFLAGS = "-fno-stack-protector";
-				PRODUCT_BUNDLE_IDENTIFIER = org.rehabman.voodoo.driver.PS2Controller;
+				PRODUCT_BUNDLE_IDENTIFIER = com.skyrilhd.PS2Controller;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = YES;
 				STRIP_STYLE = "non-global";
@@ -531,14 +655,19 @@
 		84167826161B55B2002C60E6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.0.0;
+				CURRENT_PROJECT_VERSION = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				INFOPLIST_FILE = "VoodooPS2Controller/VoodooPS2Controller-Info.plist";
-				MARKETING_VERSION = 1.0.0;
-				MODULE_NAME = com.rehabman.driver.VoodooPS2Controller;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/universal",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
+				);
+				MODULE_NAME = com.skyrilhd.VoodooPS2Controller;
 				OTHER_CFLAGS = "-fno-stack-protector";
-				PRODUCT_BUNDLE_IDENTIFIER = org.rehabman.voodoo.driver.PS2Controller;
+				PRODUCT_BUNDLE_IDENTIFIER = com.skyrilhd.PS2Controller;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = YES;
 				STRIP_STYLE = "non-global";
@@ -548,15 +677,15 @@
 		84167839161B5613002C60E6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/VoodooPS2Controller.kext/Contents/PlugIns";
-				CURRENT_PROJECT_VERSION = 1.0.0;
+				CURRENT_PROJECT_VERSION = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				INFOPLIST_FILE = "VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist";
-				MARKETING_VERSION = 1.0.0;
-				MODULE_NAME = com.rehabman.driver.VoodooPS2Keyboard;
+				MODULE_NAME = com.skyrilhd.VoodooPS2Keyboard;
 				OTHER_CFLAGS = "-fno-stack-protector";
-				PRODUCT_BUNDLE_IDENTIFIER = org.rehabman.voodoo.driver.PS2Keyboard;
+				PRODUCT_BUNDLE_IDENTIFIER = com.skyrilhd.PS2Keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = YES;
 				STRIP_STYLE = "non-global";
@@ -566,15 +695,15 @@
 		8416783A161B5613002C60E6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/VoodooPS2Controller.kext/Contents/PlugIns";
-				CURRENT_PROJECT_VERSION = 1.0.0;
+				CURRENT_PROJECT_VERSION = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				INFOPLIST_FILE = "VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist";
-				MARKETING_VERSION = 1.0.0;
-				MODULE_NAME = com.rehabman.driver.VoodooPS2Keyboard;
+				MODULE_NAME = com.skyrilhd.VoodooPS2Keyboard;
 				OTHER_CFLAGS = "-fno-stack-protector";
-				PRODUCT_BUNDLE_IDENTIFIER = org.rehabman.voodoo.driver.PS2Keyboard;
+				PRODUCT_BUNDLE_IDENTIFIER = com.skyrilhd.PS2Keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = YES;
 				STRIP_STYLE = "non-global";
@@ -584,15 +713,20 @@
 		84167861161B56C4002C60E6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/VoodooPS2Controller.kext/Contents/PlugIns";
-				CURRENT_PROJECT_VERSION = 1.0.0;
+				CURRENT_PROJECT_VERSION = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/VoodooInput/Debug/VoodooInput.kext/Contents/Resources";
 				INFOPLIST_FILE = "VoodooPS2Trackpad/VoodooPS2Trackpad-Info.plist";
-				MARKETING_VERSION = 1.0.0;
-				MODULE_NAME = com.rehabman.driver.VoodooPS2Trackpad;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/MacKernelSDK/Library/universal",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
+				);
+				MODULE_NAME = com.skyrilhd.VoodooPS2Trackpad;
 				OTHER_CFLAGS = "-fno-stack-protector";
-				PRODUCT_BUNDLE_IDENTIFIER = org.rehabman.voodoo.driver.PS2Trackpad;
+				PRODUCT_BUNDLE_IDENTIFIER = com.skyrilhd.PS2Trackpad;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = YES;
 				STRIP_STYLE = "non-global";
@@ -602,15 +736,20 @@
 		84167862161B56C4002C60E6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/VoodooPS2Controller.kext/Contents/PlugIns";
-				CURRENT_PROJECT_VERSION = 1.0.0;
+				CURRENT_PROJECT_VERSION = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/VoodooInput/Debug/VoodooInput.kext/Contents/Resources";
 				INFOPLIST_FILE = "VoodooPS2Trackpad/VoodooPS2Trackpad-Info.plist";
-				MARKETING_VERSION = 1.0.0;
-				MODULE_NAME = com.rehabman.driver.VoodooPS2Trackpad;
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/MacKernelSDK/Library/universal",
+					"$(PROJECT_DIR)/MacKernelSDK/Library/x86_64",
+				);
+				MODULE_NAME = com.skyrilhd.VoodooPS2Trackpad;
 				OTHER_CFLAGS = "-fno-stack-protector";
-				PRODUCT_BUNDLE_IDENTIFIER = org.rehabman.voodoo.driver.PS2Trackpad;
+				PRODUCT_BUNDLE_IDENTIFIER = com.skyrilhd.PS2Trackpad;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = YES;
 				STRIP_STYLE = "non-global";

--- a/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/All Kext.xcscheme
+++ b/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/All Kext.xcscheme
@@ -73,7 +73,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/VoodooPS2Controller/AppleACPIPS2Nub.cpp
+++ b/VoodooPS2Controller/AppleACPIPS2Nub.cpp
@@ -21,17 +21,17 @@
  * @APPLE_LICENSE_HEADER_END@
  */
 /*! @file       AppleACPIPS2Nub.cpp
- @abstract   AppleACPIPS2Nub class implementation
- @discussion
- Implements the ACPI PS/2 nub for ApplePS2Controller.kext.
- Reverse-engineered from the Darwin 8 binary ACPI kext.
- Copyright 2007 David Elliott
+    @abstract   AppleACPIPS2Nub class implementation
+    @discussion
+    Implements the ACPI PS/2 nub for ApplePS2Controller.kext.
+    Reverse-engineered from the Darwin 8 binary ACPI kext.
+    Copyright 2007 David Elliott
  */
 
 #include "AppleACPIPS2Nub.h"
 
 #if 0
-#define DEBUG_LOG(args...)  IOLog(args)
+#define DEBUG_LOG(args...)
 #else
 #define DEBUG_LOG(args...)
 #endif
@@ -51,23 +51,23 @@ bool AppleACPIPS2Nub::start(IOService *provider)
 {
     if (!super::start(provider))
         return false;
-    
+
     DEBUG_LOG("AppleACPIPS2Nub::start: provider=%p\n", provider);
-    
+
     /* Initialize our interrupt controller/specifier i-vars */
     m_interruptControllers = OSArray::withCapacity(2);
     m_interruptSpecifiers = OSArray::withCapacity(2);
     if(m_interruptControllers == NULL || m_interruptSpecifiers == NULL)
         return false;
-    
+
     /* Merge in the keyboard (primary) provider interrupt properties */
     mergeInterruptProperties(provider, LEGACY_KEYBOARD_IRQ);
-    
+
     /* Initialize and register our power management properties */
-    PMinit();
+	PMinit();
     registerPowerDriver(this, myTwoStates, 2);
     provider->joinPMtree(this);
-    
+
     /* Find the mouse provider */
     m_mouseProvider = findMouseDevice();
     if(m_mouseProvider != NULL)
@@ -82,26 +82,26 @@ bool AppleACPIPS2Nub::start(IOService *provider)
             }
         }
     }
-    
+
     /* Set our interrupt properties in the IO registry */
     if(m_interruptControllers->getCount() != 0 && m_interruptSpecifiers->getCount() != 0)
     {
         setProperty(gIOInterruptControllersKey, m_interruptControllers);
         setProperty(gIOInterruptSpecifiersKey, m_interruptSpecifiers);
     }
-    
+
     /* Release the arrays we allocated.  Our properties dictionary has them retained */
     m_interruptControllers->release();
     m_interruptControllers = NULL;
     m_interruptSpecifiers->release();
     m_interruptSpecifiers = NULL;
-    
+
     /* Make ourselves the ps2controller nub and register so ApplePS2Controller can find us. */
     setName("ps2controller");
     registerService();
-    
+
     DEBUG_LOG("AppleACPIPS2Nub::start: startup complete\n");
-    
+
     return true;
 }
 
@@ -136,7 +136,7 @@ void AppleACPIPS2Nub::mergeInterruptProperties(IOService *pnpProvider, long)
         return;
     if(controllers->getCount() == 0 || specifiers->getCount() == 0)
         return;
-    
+
     /* Append the first object of each array into our own respective array */
     m_interruptControllers->setObject(controllers->getObject(0));
     m_interruptSpecifiers->setObject(specifiers->getObject(0));
@@ -194,13 +194,13 @@ IOReturn AppleACPIPS2Nub::disableInterrupt(int source)
 
 bool AppleACPIPS2Nub::compareName( OSString * name, OSString ** matched ) const
 {
-    //    return gAppleACPIPlatformExpert->compareNubName( this, name, matched );
+//    return gAppleACPIPlatformExpert->compareNubName( this, name, matched );
     return( this->IORegistryEntry::compareName( name, matched ));
 }
 
 IOReturn AppleACPIPS2Nub::getResources( void )
 {
-    //    return gAppleACPIPlatformExpert->getNubResources(this);
+//    return gAppleACPIPlatformExpert->getNubResources(this);
     return( kIOReturnSuccess );
 }
 

--- a/VoodooPS2Controller/AppleACPIPS2Nub.h
+++ b/VoodooPS2Controller/AppleACPIPS2Nub.h
@@ -21,11 +21,11 @@
  * @APPLE_LICENSE_HEADER_END@
  */
 /*! @file       AppleACPIPS2Nub.h
- @abstract   AppleACPIPS2Nub class definition
- @discussion
- Implements the ACPI PS/2 nub for ApplePS2Controller.kext.
- Reverse-engineered from the Darwin 8 binary ACPI kext.
- Copyright 2007 David Elliott
+    @abstract   AppleACPIPS2Nub class definition
+    @discussion
+    Implements the ACPI PS/2 nub for ApplePS2Controller.kext.
+    Reverse-engineered from the Darwin 8 binary ACPI kext.
+    Copyright 2007 David Elliott
  */
 
 #ifndef __AppleACPIPS2Nub__
@@ -42,100 +42,100 @@
 class IOPlatformExpert;
 
 /*! @class      AppleACPIPS2Nub
- @abstract   Provides a nub that ApplePS2Controller can attach to
- @discussion
- The ApplePS2Controller driver is written to the nub provided by the
- AppleI386PlatformExpert class which exposes the controller as it is found
- on a legacy x86 machine.
- 
- To make that kext work on an ACPI machine, a nub providing the same
- service must exist.  Previous releases of the official ACPI PE included
- this class.  Newer release do not.  This implementation is intended
- to be fully ABI compatible with the one Apple used to provide.
+    @abstract   Provides a nub that ApplePS2Controller can attach to
+    @discussion
+    The ApplePS2Controller driver is written to the nub provided by the
+    AppleI386PlatformExpert class which exposes the controller as it is found
+    on a legacy x86 machine.
+
+    To make that kext work on an ACPI machine, a nub providing the same
+    service must exist.  Previous releases of the official ACPI PE included
+    this class.  Newer release do not.  This implementation is intended
+    to be fully ABI compatible with the one Apple used to provide.
  */
 class EXPORT AppleACPIPS2Nub: public IOPlatformDevice
 {
     typedef IOPlatformDevice super;
     OSDeclareDefaultStructors(AppleACPIPS2Nub);
-    
+
 private:
     /*! @field      m_mouseProvider
-     @abstract   Our second provider which provides the mouse nub
-     @discussion
-     We attach to the keyboard nub but we need to be attached to both the
-     keyboard and mouse nub in order to make ourselves a proper nub for
-     the ApplePS2Controller.kext driver.
+        @abstract   Our second provider which provides the mouse nub
+        @discussion
+        We attach to the keyboard nub but we need to be attached to both the
+        keyboard and mouse nub in order to make ourselves a proper nub for
+        the ApplePS2Controller.kext driver.
      */
     IOService *m_mouseProvider;
-    
+
     /*! @field      m_interruptControllers
-     @abstract   Our array of interrupt controllers
+        @abstract   Our array of interrupt controllers
      */
     OSArray *m_interruptControllers;
-    
+
     /*! @field      m_interruptSpecifiers
-     @abstract   Our array of interrupt specifiers
+        @abstract   Our array of interrupt specifiers
      */
     OSArray *m_interruptSpecifiers;
-    
+
     enum LegacyInterrupts
     {
         LEGACY_KEYBOARD_IRQ = 1,
         LEGACY_MOUSE_IRQ = 12,
     };
-    
+
 public:
-    virtual bool start(IOService *provider);
-    
+    bool start(IOService *provider) override;
+
     /*! @method     findMouseDevice
-     @abstract   Locates the mouse nub in the IORegistry
+        @abstract   Locates the mouse nub in the IORegistry
      */
     virtual IOService *findMouseDevice();
-    
+
     /*! @method     mergeInterruptProperties
-     @abstract   Merges the interrupt specifiers and controllers from our two providers
-     @param  pnpProvider     The provider nub
-     @discussion
-     This is called once for each of our providers.  The interrupt controller and interrupt
-     specifier objects from the provider's arrays are appended to our arrays.
+        @abstract   Merges the interrupt specifiers and controllers from our two providers
+        @param  pnpProvider     The provider nub
+        @discussion
+        This is called once for each of our providers.  The interrupt controller and interrupt
+        specifier objects from the provider's arrays are appended to our arrays.
      */
     virtual void mergeInterruptProperties(IOService *pnpProvider, long source);
-    
+
     /*! @method     registerInterrupt
-     @abstract   Overriden to translate the legacy interrupt numbers to ours
-     @discussion
-     The legacy interrupts are 1 for the keyboard and 12 (0xc) for the mouse.
-     However, the base class code works off of the controller and specifier
-     objects in our IOInterruptControllers and IOInterruptSpecifiers keys.
-     Therefore, we must translate the keyboard interrupt (1) to the index
-     into our array (0) and the mouse interrupt (12) to the index into
-     our array (1).
-     
-     This has to be done for every *Interrupt* method
+        @abstract   Overriden to translate the legacy interrupt numbers to ours
+        @discussion
+        The legacy interrupts are 1 for the keyboard and 12 (0xc) for the mouse.
+        However, the base class code works off of the controller and specifier
+        objects in our IOInterruptControllers and IOInterruptSpecifiers keys.
+        Therefore, we must translate the keyboard interrupt (1) to the index
+        into our array (0) and the mouse interrupt (12) to the index into
+        our array (1).
+
+        This has to be done for every *Interrupt* method
      */
-    virtual IOReturn registerInterrupt(int source, OSObject *target,
-                                       IOInterruptAction handler,
-                                       void *refCon = 0);
-    virtual IOReturn unregisterInterrupt(int source);
-    virtual IOReturn getInterruptType(int source, int *interruptType);
-    virtual IOReturn enableInterrupt(int source);
-    virtual IOReturn disableInterrupt(int source);
-    
+    IOReturn registerInterrupt(int source, OSObject *target,
+				       IOInterruptAction handler,
+				       void *refCon = 0) override;
+    IOReturn unregisterInterrupt(int source) override;
+    IOReturn getInterruptType(int source, int *interruptType) override;
+    IOReturn enableInterrupt(int source) override;
+    IOReturn disableInterrupt(int source) override;
+
     /*! @method     compareName
-     @abstract   Overridden to call the IOPlatformExpert compareNubName method
-     @discussion
-     I have no idea why this is done, but the Apple code did it, so this
-     code does too.
+        @abstract   Overridden to call the IOPlatformExpert compareNubName method
+        @discussion
+        I have no idea why this is done, but the Apple code did it, so this
+        code does too.
      */
-    virtual bool compareName( OSString * name, OSString ** matched = 0 ) const;
-    
+    bool compareName( OSString * name, OSString ** matched = 0 ) const override;
+
     /*! @method     getResources
-     @abstract   Overridden to call the IOPlatformExpert getNubResources method
-     @discussion
-     I have no idea why this is done, but the Apple code did it, so this
-     code does too.
+        @abstract   Overridden to call the IOPlatformExpert getNubResources method
+        @discussion
+        I have no idea why this is done, but the Apple code did it, so this
+        code does too.
      */
-    virtual IOReturn getResources( void );
+    IOReturn getResources( void ) override;
     
     /*! @method     message
      @abstract   Overridden to receive ACPI notifications
@@ -144,7 +144,7 @@ public:
      ACPI Notify can be used to push keystrokes.  This is used to convert ACPI
      keys such that they appear to be PS2 keys.
      */
-    virtual IOReturn message( UInt32 type, IOService* provider, void* argument );
+    IOReturn message( UInt32 type, IOService* provider, void* argument ) override;
 };
 
 #endif

--- a/VoodooPS2Controller/ApplePS2Device.cpp
+++ b/VoodooPS2Controller/ApplePS2Device.cpp
@@ -31,53 +31,53 @@ OSDefineMetaClassAndStructors(ApplePS2Device, IOService);
 
 bool ApplePS2Device::attach(IOService * provider)
 {
-    if (!super::attach(provider))
-        return false;
-    
-    assert(_controller == 0);
-    _controller = (ApplePS2Controller*)provider;
-    _controller->retain();
-    
-    return true;
+  if (!super::attach(provider))
+      return false;
+
+  assert(_controller == 0);
+  _controller = (ApplePS2Controller*)provider;
+  _controller->retain();
+
+  return true;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 void ApplePS2Device::detach( IOService * provider )
 {
-    assert(_controller == provider);
-    _controller->release();
-    _controller = 0;
-    
-    super::detach(provider);
+  assert(_controller == provider);
+  _controller->release();
+  _controller = 0;
+
+  super::detach(provider);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 PS2Request * ApplePS2Device::allocateRequest(int max)
 {
-    return _controller->allocateRequest(max);
+  return _controller->allocateRequest(max);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 void ApplePS2Device::freeRequest(PS2Request * request)
 {
-    _controller->freeRequest(request);
+  _controller->freeRequest(request);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 bool ApplePS2Device::submitRequest(PS2Request * request)
 {
-    return _controller->submitRequest(request);
+  return _controller->submitRequest(request);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 void ApplePS2Device::submitRequestAndBlock(PS2Request * request)
 {
-    _controller->submitRequestAndBlock(request);
+  _controller->submitRequestAndBlock(request);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -102,8 +102,8 @@ void ApplePS2Device::unlock()
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 void ApplePS2Device::installInterruptAction(OSObject *         target,
-                                            PS2InterruptAction interruptAction,
-                                            PS2PacketAction packetAction)
+                                                    PS2InterruptAction interruptAction,
+                                                    PS2PacketAction packetAction)
 {
     _controller->installInterruptAction(_deviceType, target, interruptAction, packetAction);
 }
@@ -118,8 +118,8 @@ void ApplePS2Device::uninstallInterruptAction()
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 void ApplePS2Device::installPowerControlAction(
-                                               OSObject *            target,
-                                               PS2PowerControlAction action)
+                                                       OSObject *            target,
+                                                       PS2PowerControlAction action)
 {
     _controller->installPowerControlAction(_deviceType, target, action);
 }

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -31,8 +31,10 @@
 
 #ifdef DEBUG_MSG
 #define DEBUG_LOG(args...)  do { IOLog(args); } while (0)
+#define INFO_LOG(args...)  do { IOLog(args); IOSleep(1000); } while (0)
 #else
 #define DEBUG_LOG(args...)  do { } while (0)
+#define INFO_LOG(args...)  do { } while (0)
 #endif
 
 #define countof(x) (sizeof((x))/sizeof((x)[0]))
@@ -585,8 +587,8 @@ protected:
     PS2DeviceType       _deviceType;
     
 public:
-    virtual bool attach(IOService * provider);
-    virtual void detach(IOService * provider);
+    bool attach(IOService * provider) override;
+    void detach(IOService * provider) override;
     
     // Interrupt Handling Routines
     

--- a/VoodooPS2Controller/ApplePS2KeyboardDevice.cpp
+++ b/VoodooPS2Controller/ApplePS2KeyboardDevice.cpp
@@ -2,13 +2,13 @@
  * Copyright (c) 1998-2000 Apple Computer, Inc. All rights reserved.
  *
  * @APPLE_LICENSE_HEADER_START@
- *
+ * 
  * The contents of this file constitute Original Code as defined in and
  * are subject to the Apple Public Source License Version 1.1 (the
  * "License").  You may not use this file except in compliance with the
  * License.  Please obtain a copy of the License at
  * http://www.apple.com/publicsource and read it before using this file.
- *
+ * 
  * This Original Code and all software distributed under the License are
  * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
@@ -16,7 +16,7 @@
  * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.  Please see the
  * License for the specific language governing rights and limitations
  * under the License.
- *
+ * 
  * @APPLE_LICENSE_HEADER_END@
  */
 

--- a/VoodooPS2Controller/ApplePS2KeyboardDevice.h
+++ b/VoodooPS2Controller/ApplePS2KeyboardDevice.h
@@ -31,9 +31,9 @@ class EXPORT ApplePS2KeyboardDevice : public ApplePS2Device
 {
     typedef ApplePS2Device super;
     OSDeclareDefaultStructors(ApplePS2KeyboardDevice);
-    
+
 public:
-    virtual bool init();
+    bool init() override;
 };
 
 #endif /* !_APPLEPS2KEYBOARDDEVICE_H */

--- a/VoodooPS2Controller/ApplePS2MouseDevice.h
+++ b/VoodooPS2Controller/ApplePS2MouseDevice.h
@@ -31,9 +31,9 @@ class EXPORT ApplePS2MouseDevice : public ApplePS2Device
 {
     typedef ApplePS2Device super;
     OSDeclareDefaultStructors(ApplePS2MouseDevice);
-    
+
 public:
-    virtual bool init();
+    bool init() override;
 };
 
 #endif /* !_APPLEPS2MOUSEDEVICE_H */

--- a/VoodooPS2Controller/VoodooPS2Controller-Info.plist
+++ b/VoodooPS2Controller/VoodooPS2Controller-Info.plist
@@ -15,17 +15,17 @@
 	<key>CFBundlePackageType</key>
 	<string>KEXT</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>${MODULE_VERSION}</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>${MODULE_VERSION}</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>ACPI PS/2 Nub</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
-			<string>org.rehabman.voodoo.driver.PS2Controller</string>
+			<string>com.skyrilhd.PS2Controller</string>
 			<key>IOClass</key>
 			<string>AppleACPIPS2Nub</string>
 			<key>IONameMatch</key>
@@ -46,7 +46,7 @@
 		<key>ApplePS2Controller</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
-			<string>org.rehabman.voodoo.driver.PS2Controller</string>
+			<string>com.skyrilhd.PS2Controller</string>
 			<key>IOClass</key>
 			<string>ApplePS2Controller</string>
 			<key>IONameMatch</key>
@@ -138,7 +138,5 @@
 	</dict>
 	<key>OSBundleRequired</key>
 	<string>Console</string>
-	<key>Source Code</key>
-	<string>https://github.com/RehabMan/OS-X-Voodoo-PS2-Controller</string>
 </dict>
 </plist>

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -277,18 +277,8 @@ bool ApplePS2Controller::init(OSDictionary* dict)
     IOLog("offsetof(TPS2Request<1>,commands): %lu\n", offsetof(TPS2Request<1>, commands));
 #endif
     // verify that compiler is working correctly wrt PS2Request/TPS2Request
-    if (sizeof(PS2Request) != sizeof(TPS2Request<0>))
-    {
-        IOLog("ApplePS2Controller::init: PS2Request size mismatch (%lu != %lu)\n",
-              sizeof(PS2Request), sizeof(TPS2Request<0>));
-        return false;
-    }
-    if (offsetof(PS2Request,commands) != offsetof(TPS2Request<>,commands))
-    {
-        IOLog("ApplePS2Controller::init: PS2Request.commands offset mismatch (%lu != %lu)\n",
-              offsetof(PS2Request,commands), offsetof(PS2Request,commands));
-        return false;
-    }
+    static_assert(sizeof(PS2Request) == sizeof(TPS2Request<0>), "Invalid PS2Request size");
+    static_assert(offsetof(PS2Request,commands) == offsetof(TPS2Request<>,commands), "Invalid PS2Request commands offset");
     
     // find config specific to Platform Profile
     OSDictionary* list = OSDynamicCast(OSDictionary, dict->getObject(kPlatformProfile));
@@ -641,7 +631,7 @@ bool ApplePS2Controller::start(IOService * provider)
         OSSafeReleaseNULL(_mouseDevice);
         OSSafeReleaseNULL(_interruptSourceMouse);
     }
-    
+	   
     if (_keyboardDevice)
         _keyboardDevice->registerService();
     if (_mouseDevice)

--- a/VoodooPS2Controller/VoodooPS2Controller.h
+++ b/VoodooPS2Controller/VoodooPS2Controller.h
@@ -291,17 +291,17 @@ private:
     
     virtual void dispatchDriverPowerControl(UInt32 whatToDo, PS2DeviceType deviceType);
 #if DEBUGGER_SUPPORT
-    virtual void free(void);
+    void free(void) override;
 #endif
     IOReturn setPropertiesGated(OSObject* props);
     void submitRequestAndBlockGated(PS2Request* request);
     
 public:
-    virtual bool init(OSDictionary * properties);
-    virtual bool start(IOService * provider);
-    virtual void stop(IOService * provider);
+    bool init(OSDictionary * properties) override;
+    bool start(IOService * provider) override;
+    void stop(IOService * provider) override;
     
-    virtual IOWorkLoop * getWorkLoop() const;
+    IOWorkLoop * getWorkLoop() const override;
     
     virtual void installInterruptAction(PS2DeviceType      deviceType,
                                         OSObject *         target,
@@ -316,8 +316,8 @@ public:
     virtual UInt8        setCommandByte(UInt8 setBits, UInt8 clearBits);
     void setCommandByteGated(PS2Request* request);
     
-    virtual IOReturn setPowerState(unsigned long powerStateOrdinal,
-                                   IOService *   policyMaker);
+    IOReturn setPowerState(unsigned long powerStateOrdinal,
+                                   IOService *   policyMaker) override;
     
     virtual void installPowerControlAction(PS2DeviceType         deviceType,
                                            OSObject *            target,
@@ -332,7 +332,7 @@ public:
     virtual void uninstallMessageAction(PS2DeviceType deviceType);
     virtual void dispatchMessage(PS2DeviceType deviceType, int message, void* data);
     
-    virtual IOReturn setProperties(OSObject* props);
+    IOReturn setProperties(OSObject* props) override;
     virtual void lock();
     virtual void unlock();
     

--- a/VoodooPS2Keyboard/ApplePS2ToADBMap.h
+++ b/VoodooPS2Keyboard/ApplePS2ToADBMap.h
@@ -33,8 +33,8 @@
 // http://download.microsoft.com/download/1/6/1/161ba512-40e2-4cc9-843a-923143f3456c/translate.pdf
 static const UInt8 PS2ToADBMapStock[ADB_CONVERTER_LEN] =
 {
-    /*  ADB        AT  ANSI Key-Legend
-     ======================== */
+/*  ADB        AT  ANSI Key-Legend
+    ======================== */
     DEADKEY,// 00
     0x35,   // 01  Escape
     0x12,   // 02  1!

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard-Breakless-Info.plist
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard-Breakless-Info.plist
@@ -2,14 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Source Code</key>
-	<string>https://github.com/RehabMan/OS-X-Voodoo-PS2-Controller</string>
 	<key>CFBundleGetInfoString</key>
 	<string>${MODULE_VERSION}, Copyright Apple Computer, Inc. 2000-2003, RehabMan 2012-2013</string>
 	<key>CFBundleExecutable</key>
 	<string>VoodooPS2Keyboard</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.rehabman.voodoo.driver.PS2Keyboard</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -27,7 +25,7 @@
 		<key>ApplePS2Keyboard</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
-			<string>org.rehabman.voodoo.driver.PS2Keyboard</string>
+			<string>com.skyrilhd.PS2Keyboard</string>
 			<key>IOClass</key>
 			<string>ApplePS2Keyboard</string>
 			<key>IOProviderClass</key>
@@ -152,8 +150,8 @@
 	</dict>
 	<key>OSBundleLibraries</key>
 	<dict>
-		<key>com.apple.iokit.IOHIDSystem</key>
-		<string>1.1</string>
+		<key>com.apple.iokit.IOHIDFamily</key>
+		<string>1.0.0b1</string>
 		<key>com.apple.kpi.bsd</key>
 		<string>8.0.0</string>
 		<key>com.apple.kpi.iokit</key>
@@ -164,8 +162,8 @@
 		<string>8.0.0</string>
 		<key>com.apple.kpi.unsupported</key>
 		<string>8.0.0</string>
-		<key>org.rehabman.voodoo.driver.PS2Controller</key>
-		<string>2.8.15</string>
+		<key>com.skyrilhd.PS2Controller</key>
+		<string>${MODULE_VERSION}</string>
 	</dict>
 	<key>OSBundleRequired</key>
 	<string>Console</string>

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist
@@ -15,17 +15,17 @@
 	<key>CFBundlePackageType</key>
 	<string>KEXT</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>${MODULE_VERSION}</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>${MODULE_VERSION}</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>ApplePS2Keyboard</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
-			<string>org.rehabman.voodoo.driver.PS2Keyboard</string>
+			<string>com.skyrilhd.PS2Keyboard</string>
 			<key>IOClass</key>
 			<string>ApplePS2Keyboard</string>
 			<key>IOProviderClass</key>
@@ -668,8 +668,8 @@
 	</dict>
 	<key>OSBundleLibraries</key>
 	<dict>
-		<key>com.apple.iokit.IOHIDSystem</key>
-		<string>1.1</string>
+		<key>com.apple.iokit.IOHIDFamily</key>
+		<string>1.0.0b1</string>
 		<key>com.apple.kpi.bsd</key>
 		<string>8.0.0</string>
 		<key>com.apple.kpi.iokit</key>
@@ -680,12 +680,10 @@
 		<string>8.0.0</string>
 		<key>com.apple.kpi.unsupported</key>
 		<string>8.0.0</string>
-		<key>org.rehabman.voodoo.driver.PS2Controller</key>
-		<string>1.0.0</string>
+		<key>com.skyrilhd.PS2Controller</key>
+		<string>${MODULE_VERSION}</string>
 	</dict>
 	<key>OSBundleRequired</key>
 	<string>Console</string>
-	<key>Source Code</key>
-	<string>https://github.com/RehabMan/OS-X-Voodoo-PS2-Controller</string>
 </dict>
 </plist>

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard-RemapFN-Info.plist
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard-RemapFN-Info.plist
@@ -2,14 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Source Code</key>
-	<string>https://github.com/RehabMan/OS-X-Voodoo-PS2-Controller</string>
 	<key>CFBundleGetInfoString</key>
 	<string>${MODULE_VERSION}, Copyright Apple Computer, Inc. 2000-2003, RehabMan 2012-2013</string>
 	<key>CFBundleExecutable</key>
 	<string>VoodooPS2Keyboard</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.rehabman.voodoo.driver.PS2Keyboard</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -27,7 +25,7 @@
 		<key>ApplePS2Keyboard</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
-			<string>org.rehabman.voodoo.driver.PS2Keyboard</string>
+			<string>com.skyrilhd.PS2Keyboard</string>
 			<key>IOClass</key>
 			<string>ApplePS2Keyboard</string>
 			<key>IOProviderClass</key>
@@ -140,8 +138,8 @@
 	</dict>
 	<key>OSBundleLibraries</key>
 	<dict>
-		<key>com.apple.iokit.IOHIDSystem</key>
-		<string>1.1</string>
+		<key>com.apple.iokit.IOHIDFamily</key>
+		<string>1.0.0b1</string>
 		<key>com.apple.kpi.bsd</key>
 		<string>8.0.0</string>
 		<key>com.apple.kpi.iokit</key>
@@ -152,8 +150,8 @@
 		<string>8.0.0</string>
 		<key>com.apple.kpi.unsupported</key>
 		<string>8.0.0</string>
-		<key>org.rehabman.voodoo.driver.PS2Controller</key>
-		<string>2.8.15</string>
+		<key>com.skyrilhd.PS2Controller</key>
+		<string>${MODULE_VERSION}</string>
 	</dict>
 	<key>OSBundleRequired</key>
 	<string>Console</string>

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -176,18 +176,6 @@ error:
     return false;
 }
 
-#ifdef DEBUG
-static void logKeySequence(const char* header, UInt16* pAction)
-{
-    DEBUG_LOG("ApplePS2Keyboard: %s { ", header);
-    for (; *pAction; ++pAction)
-    {
-        DEBUG_LOG("%04x, ", *pAction);
-    }
-    DEBUG_LOG("}\n");
-}
-#endif
-
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 bool ApplePS2Keyboard::init(OSDictionary * dict)
@@ -228,7 +216,7 @@ bool ApplePS2Keyboard::init(OSDictionary * dict)
     _swapcommandoption = false;
     _sleepEjectTimer = 0;
     _cmdGate = 0;
-    
+        
     _fkeymode = 0;
     _fkeymodesupported = false;
     _keysStandard = 0;
@@ -335,17 +323,6 @@ bool ApplePS2Keyboard::init(OSDictionary * dict)
     // populate rest of values via setParamProperties
     setParamPropertiesGated(config);
     OSSafeReleaseNULL(config);
-    
-#ifdef DEBUG
-    logKeySequence("Swipe Up:", _actionSwipeUp);
-    logKeySequence("Swipe Down:", _actionSwipeDown);
-    logKeySequence("Swipe Left:", _actionSwipeLeft);
-    logKeySequence("Swipe Right:", _actionSwipeRight);
-    logKeySequence("Swipe 4 Up:", _actionSwipe4Up);
-    logKeySequence("Swipe 4 Down:", _actionSwipe4Down);
-    logKeySequence("Swipe 4 Left:", _actionSwipe4Left);
-    logKeySequence("Swipe 4 Right:", _actionSwipe4Right);
-#endif
     
     return true;
 }
@@ -1956,7 +1933,7 @@ void ApplePS2Keyboard::receiveMessage(int message, void* data)
             DEBUG_LOG("ApplePS2Keyboard: Synaptic Trackpad call Zoom In\n");
             sendKeySequence(_actionZoomIn);
             break;
-            
+
         case kPS2M_zoomOut:
             DEBUG_LOG("ApplePS2Keyboard: Synaptic Trackpad call Zoom Out\n");
             sendKeySequence(_actionZoomOut);

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -40,16 +40,16 @@
 #define KBV_BITS_MASK           31
 #define KBV_BITS_SHIFT          5       // 1<<5 == 32, for cheap divide
 #define KBV_NUNITS ((KBV_NUM_KEYCODES + \
-(KBV_BITS_PER_UNIT-1))/KBV_BITS_PER_UNIT)
+            (KBV_BITS_PER_UNIT-1))/KBV_BITS_PER_UNIT)
 
 #define KBV_KEYDOWN(n) \
-(_keyBitVector)[((n)>>KBV_BITS_SHIFT)] |= (1 << ((n) & KBV_BITS_MASK))
+    (_keyBitVector)[((n)>>KBV_BITS_SHIFT)] |= (1 << ((n) & KBV_BITS_MASK))
 
 #define KBV_KEYUP(n) \
-(_keyBitVector)[((n)>>KBV_BITS_SHIFT)] &= ~(1 << ((n) & KBV_BITS_MASK))
+    (_keyBitVector)[((n)>>KBV_BITS_SHIFT)] &= ~(1 << ((n) & KBV_BITS_MASK))
 
 #define KBV_IS_KEYDOWN(n) \
-(((_keyBitVector)[((n)>>KBV_BITS_SHIFT)] & (1 << ((n) & KBV_BITS_MASK))) != 0)
+    (((_keyBitVector)[((n)>>KBV_BITS_SHIFT)] & (1 << ((n) & KBV_BITS_MASK))) != 0)
 
 #define KBV_NUM_SCANCODES       256
 
@@ -70,7 +70,7 @@ class EXPORT ApplePS2Keyboard : public IOHIKeyboard
 {
     typedef IOHIKeyboard super;
     OSDeclareDefaultStructors(ApplePS2Keyboard);
-    
+
 private:
     ApplePS2KeyboardDevice *    _device;
     UInt32                      _keyBitVector[KBV_NUNITS];
@@ -82,7 +82,7 @@ private:
     bool                        _messageHandlerInstalled;
     UInt8                       _ledState;
     IOCommandGate*              _cmdGate;
-    
+
     // for keyboard remapping
     UInt16                      _PS2modifierState;
     UInt16                      _PS2ToPS2Map[KBV_NUM_SCANCODES*2];
@@ -101,7 +101,7 @@ private:
     // dealing with sleep key delay
     IOTimerEventSource*         _sleepEjectTimer;
     UInt32                      _maxsleeppresstime;
-    
+
     // configuration items for swipe actions
     UInt16                      _actionSwipeUp[16];
     UInt16                      _actionSwipeDown[16];
@@ -114,12 +114,12 @@ private:
     
     UInt16                      _actionZoomIn[16];
     UInt16                      _actionZoomOut[16];
-    
+
     // ACPI support for screen brightness
     IOACPIPlatformDevice *      _provider;
     int *                       _brightnessLevels;
     int                         _brightnessCount;
-    
+
     // ACPI support for keyboard backlight
     int *                       _backlightLevels;
     int                         _backlightCount;
@@ -145,7 +145,7 @@ private:
     void modifyKeyboardBacklight(int adbKeyCode, bool goingDown);
     void modifyScreenBrightness(int adbKeyCode, bool goingDown);
     inline bool checkModifierState(UInt16 mask)
-    { return mask == (_PS2modifierState & mask); }
+        { return mask == (_PS2modifierState & mask); }
     
     void loadCustomPS2Map(OSArray* pArray);
     void loadBreaklessPS2(OSDictionary* dict, const char* name);
@@ -159,39 +159,39 @@ private:
     bool invertMacros(const UInt8* packet);
     void dispatchInvertBuffer();
     static bool compareMacro(const UInt8* packet, const UInt8* data, int count);
-    
+
 protected:
-    virtual const unsigned char * defaultKeymapOfLength(UInt32 * length);
-    virtual void setAlphaLockFeedback(bool locked);
-    virtual void setNumLockFeedback(bool locked);
-    virtual UInt32 maxKeyCodes();
+    const unsigned char * defaultKeymapOfLength(UInt32 * length) override;
+    void setAlphaLockFeedback(bool locked) override;
+    void setNumLockFeedback(bool locked) override;
+    UInt32 maxKeyCodes() override;
     inline void dispatchKeyboardEventX(unsigned int keyCode, bool goingDown, uint64_t time)
-    { dispatchKeyboardEvent(keyCode, goingDown, *(AbsoluteTime*)&time); }
+        { dispatchKeyboardEvent(keyCode, goingDown, *(AbsoluteTime*)&time); }
     inline void setTimerTimeout(IOTimerEventSource* timer, uint64_t time)
-    { timer->setTimeout(*(AbsoluteTime*)&time); }
+        { timer->setTimeout(*(AbsoluteTime*)&time); }
     inline void cancelTimer(IOTimerEventSource* timer)
-    { timer->cancelTimeout(); }
-    
+        { timer->cancelTimeout(); }
+
 public:
-    virtual bool init(OSDictionary * dict);
-    virtual void free();
-    virtual ApplePS2Keyboard * probe(IOService * provider, SInt32 * score);
-    
-    virtual bool start(IOService * provider);
-    virtual void stop(IOService * provider);
-    
+    bool init(OSDictionary * dict) override;
+    void free() override;
+    ApplePS2Keyboard * probe(IOService * provider, SInt32 * score) override;
+
+    bool start(IOService * provider) override;
+    void stop(IOService * provider) override;
+
     virtual PS2InterruptResult interruptOccurred(UInt8 scanCode);
     virtual void packetReady();
     
     virtual void receiveMessage(int message, void* data);
     
-    virtual UInt32 deviceType();
-    virtual UInt32 interfaceID();
+    UInt32 deviceType() override;
+    UInt32 interfaceID() override;
     
-    virtual IOReturn setParamProperties(OSDictionary* dict);
-    virtual IOReturn setProperties (OSObject *props);
+  	IOReturn setParamProperties(OSDictionary* dict) override;
+    IOReturn setProperties (OSObject *props) override;
     
-    virtual IOReturn message(UInt32 type, IOService* provider, void* argument);
+    IOReturn message(UInt32 type, IOService* provider, void* argument) override;
 };
 
 #endif /* _APPLEPS2KEYBOARD_H */

--- a/VoodooPS2Trackpad/VoodooPS2Common.h
+++ b/VoodooPS2Trackpad/VoodooPS2Common.h
@@ -1,0 +1,20 @@
+//
+ //  VoodooPS2TrackpadCommon.h
+ //  VoodooPS2Trackpad
+ //
+ //  Created by Le Bao Hiep on 27/09/2020.
+ //  Copyright © 2020 Acidanthera. All rights reserved.
+ //
+
+ #ifndef VoodooPS2TrackpadCommon_h
+ #define VoodooPS2TrackpadCommon_h
+
+ typedef enum {
+     FORCE_TOUCH_DISABLED = 0,
+     FORCE_TOUCH_BUTTON = 1,
+     FORCE_TOUCH_THRESHOLD = 2,
+     FORCE_TOUCH_VALUE = 3,
+     FORCE_TOUCH_CUSTOM = 4
+ } ForceTouchMode;
+
+ #endif /* VoodooPS2TrackpadCommon_h */

--- a/VoodooPS2Trackpad/VoodooPS2Trackpad-Info.plist
+++ b/VoodooPS2Trackpad/VoodooPS2Trackpad-Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleExecutable</key>
 	<string>VoodooPS2Trackpad</string>
 	<key>CFBundleGetInfoString</key>
-	<string>${MODULE_VERSION}, Copyright Apple Computer, Inc. 2002-2003, mackerintel 2008, RehabMan 2012-2013, Dr Hurt 2016</string>
+	<string>${MODULE_VERSION}, Copyright Apple Computer, Inc. 2002-2003, mackerintel 2008, RehabMan 2012-2013, Dr Hurt 2016, SkyrilHD 2021</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -15,21 +15,17 @@
 	<key>CFBundlePackageType</key>
 	<string>KEXT</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>${MODULE_VERSION}</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>${MODULE_VERSION}</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>ALPS TouchPad</key>
 		<dict>
-			<key>ApplePreferenceCapability</key>
-			<true/>
-			<key>ApplePreferenceIdentifier</key>
-			<string>com.apple.AppleMultitouchTrackpad</string>
 			<key>CFBundleIdentifier</key>
-			<string>org.rehabman.voodoo.driver.PS2Trackpad</string>
+			<string>com.skyrilhd.PS2Trackpad</string>
 			<key>IOClass</key>
 			<string>ALPS</string>
 			<key>IOProbeScore</key>
@@ -44,145 +40,70 @@
 			<dict>
 				<key>Default</key>
 				<dict>
-					<key>BogusDeltaThreshX</key>
-					<integer>0</integer>
-					<key>BogusDeltaThreshY</key>
-					<integer>0</integer>
-					<key>CenterX</key>
-					<integer>3000</integer>
-					<key>CenterY</key>
-					<integer>2100</integer>
-					<key>CircularScrollDivisor</key>
-					<integer>0</integer>
-					<key>CircularScrollTrigger</key>
-					<integer>0</integer>
 					<key>DisableDevice</key>
 					<false/>
 					<key>DisableLEDUpdating</key>
 					<false/>
-					<key>DivisorX</key>
-					<integer>5</integer>
-					<key>DivisorY</key>
-					<integer>5</integer>
 					<key>DoubleSmoothness</key>
 					<true/>
-					<key>DoubleTapThresholdX</key>
-					<integer>100</integer>
-					<key>DoubleTapThresholdY</key>
-					<integer>100</integer>
-					<key>DragExitDelayTime</key>
-					<integer>750000000</integer>
 					<key>DragLockTempMask</key>
 					<integer>1048592</integer>
-					<key>Dragging</key>
-					<integer>1</integer>
-					<key>EdgeBottom</key>
-					<integer>500</integer>
-					<key>EdgeLeft</key>
-					<integer>1700</integer>
-					<key>EdgeRight</key>
-					<integer>5200</integer>
-					<key>EdgeTop</key>
-					<integer>2940</integer>
-					<key>FingerChangeIgnoreDeltas</key>
-					<integer>1</integer>
 					<key>FingerZ</key>
 					<integer>5</integer>
-					<key>HorizontalScrollDivisor</key>
+					<key>ForceTouchCustomDownThreshold</key>
+					<string>90</string>
+					<key>ForceTouchCustomPower</key>
+					<string>8</string>
+					<key>ForceTouchCustomUpThreshold</key>
+					<string>20</string>
+					<key>ForceTouchMode</key>
 					<integer>0</integer>
-					<key>ImmediateClick</key>
-					<true/>
-					<key>MaxDragTime</key>
-					<integer>180000000</integer>
-					<key>MaxTapTime</key>
-					<integer>130000000</integer>
-					<key>MomentumScrollDivisor</key>
+					<key>ForceTouchPressureThreshold</key>
 					<integer>100</integer>
-					<key>MomentumScrollMultiplier</key>
-					<integer>98</integer>
-					<key>MomentumScrollSamplesMin</key>
-					<integer>3</integer>
-					<key>MomentumScrollThreshY</key>
-					<integer>7</integer>
-					<key>MomentumScrollTimer</key>
-					<integer>10000000</integer>
-					<key>MultiFingerHorizontalDivisor</key>
-					<integer>5</integer>
-					<key>MultiFingerVerticalDivisor</key>
-					<integer>5</integer>
+					<key>LogicalXMultiplier</key>
+					<integer>1</integer>
+					<key>LogicalYMultiplier</key>
+					<integer>1</integer>
+					<key>PhysicalXMultiplier</key>
+					<integer>1</integer>
+					<key>PhysicalYMultiplier</key>
+					<integer>1</integer>
 					<key>QuietTimeAfterTyping</key>
 					<integer>500000000</integer>
 					<key>Resolution</key>
 					<integer>400</integer>
-					<key>ScrollDeltaThreshX</key>
-					<integer>0</integer>
-					<key>ScrollDeltaThreshY</key>
-					<integer>0</integer>
-					<key>ScrollExitDelayTime</key>
-					<integer>10000</integer>
 					<key>ScrollResolution</key>
 					<integer>400</integer>
-					<key>SmoothInput</key>
-					<true/>
-					<key>StickyHorizontalScrolling</key>
-					<false/>
-					<key>StickyMultiFingerScrolling</key>
-					<false/>
-					<key>StickyVerticalScrolling</key>
-					<false/>
-					<key>SwapDoubleTriple</key>
-					<false/>
-					<key>SwipeDeltaX</key>
-					<integer>400</integer>
-					<key>SwipeDeltaY</key>
-					<integer>400</integer>
-					<key>TapThresholdX</key>
-					<integer>50</integer>
-					<key>TapThresholdY</key>
-					<integer>50</integer>
 					<key>USBMouseStopsTrackpad</key>
 					<integer>0</integer>
 					<key>UnitsPerMMX</key>
 					<integer>50</integer>
 					<key>UnitsPerMMY</key>
 					<integer>50</integer>
-					<key>UnsmoothInput</key>
-					<false/>
-					<key>VerticalScrollDivisor</key>
-					<integer>0</integer>
 					<key>WakeDelay</key>
 					<integer>1000</integer>
-					<key>ZLimit</key>
-					<integer>255</integer>
-					<key>ZoneBottom</key>
-					<integer>0</integer>
-					<key>ZoneLeft</key>
-					<integer>567</integer>
-					<key>ZoneRight</key>
-					<integer>1733</integer>
-					<key>ZoneTop</key>
-					<integer>99999</integer>
 				</dict>
 			</dict>
 			<key>ProductID</key>
 			<integer>547</integer>
-			<key>SupportsGestureScrolling</key>
-			<true/>
-			<key>TrackpadEmbedded</key>
-			<true/>
-			<key>TrackpadFourFingerGestures</key>
-			<true/>
-			<key>TrackpadSecondaryClickCorners</key>
-			<true/>
-			<key>TrackpadThreeFingerDrag</key>
-			<true/>
 			<key>VendorID</key>
 			<integer>1452</integer>
+		</dict>
+		<key>Native Multitouch Engine</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.skyrilhd.PS2Trackpad</string>
+			<key>IOClass</key>
+			<string>VoodooPS2NativeEngine</string>
+			<key>IOMatchCategory</key>
+			<string>VoodooPS2NativeEngine</string>
+			<key>IOProviderClass</key>
+			<string>VoodooPS2MultitouchInterface</string>
 		</dict>
 	</dict>
 	<key>OSBundleLibraries</key>
 	<dict>
-		<key>com.apple.iokit.IOHIDSystem</key>
+		<key>com.apple.iokit.IOHIDFamily</key>
 		<string>1.0.0b1</string>
 		<key>com.apple.kpi.iokit</key>
 		<string>9.0.0</string>
@@ -190,12 +111,10 @@
 		<string>9.0.0</string>
 		<key>com.apple.kpi.mach</key>
 		<string>9.0.0</string>
-		<key>org.rehabman.voodoo.driver.PS2Controller</key>
-		<string>1.0.0</string>
+		<key>com.skyrilhd.PS2Controller</key>
+		<string>${MODULE_VERSION}</string>
 	</dict>
 	<key>OSBundleRequired</key>
 	<string>Console</string>
-	<key>Source Code</key>
-	<string>https://github.com/RehabMan/OS-X-Voodoo-PS2-Controller</string>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request adds Magic Trackpad 2 Emulation, done by VoodooInput, to enable gestures for ALPS trackpads. The aim is to make the code polished and push it to Acidanthera's VoodooPS2 repo.

Changes since the old code:
- [x] upstream from Linux repo
- [x] Code clean-up
- [x] Merged codes from Acidanthera repo
- [x] changed Bundle Identifier to avoid confusion
- [x] added VoodooInput support

What is working:
- [x] 1 finger
- [x] 2 fingers
- [x] 3 fingers
- [x] 4 fingers
- [x] 5 fingers
- [x] all gestures shown in System Preferences

What is not working:
- [ ] Notification Center (margin needs to be added)

Compatibility:
- [ ] V1
- [ ] V2
- [ ] V3
- [ ] V4
- [ ] V5
- [ ] V6
- [x] V7
- [ ] V8

I hope by publishing the code, more developers would help to make more trackpads compatible.