### PR TITLE
Fix 2 fingers jumping

### DIFF
--- a/VoodooPS2Trackpad/alps.cpp
+++ b/VoodooPS2Trackpad/alps.cpp
@@ -3403,7 +3403,6 @@ void ALPS::alps_parse_hw_state(const UInt8 buf[], struct alps_fields &f)
     f.mt[0].y = priv.y_max - f.mt[0].y;
     f.mt[1].y = priv.y_max - f.mt[1].y;
     
-    // TODO: maybe move this to alps_parse_hw_state
     // scale x & y to the axis which has the most resolution
     if (xupmm < yupmm) {
         f.mt[0].x = f.mt[0].x * yupmm / xupmm;

--- a/VoodooPS2Trackpad/alps.cpp
+++ b/VoodooPS2Trackpad/alps.cpp
@@ -3384,7 +3384,7 @@ void ALPS::assignFingerType(virtual_finger_state &vf) {
     
 }
 
-void ALPS::alps_parse_hw_state(const UInt8 buf[], struct alps_fields &g)
+void ALPS::alps_parse_hw_state(const UInt8 buf[], struct alps_fields &f)
 {
     // Check if input is disabled via ApplePS2Keyboard request
     if (ignoreall)
@@ -3393,7 +3393,7 @@ void ALPS::alps_parse_hw_state(const UInt8 buf[], struct alps_fields &g)
     UInt8 *packet = _ringBuffer.tail();
     // get fingercounts from packets
     int fingers = 0;
-    struct alps_fields f;
+    //struct alps_fields f;
     
     memset(&f, 0, sizeof(alps_fields));
     

--- a/VoodooPS2Trackpad/alps.cpp
+++ b/VoodooPS2Trackpad/alps.cpp
@@ -3301,9 +3301,6 @@ void ALPS::packetReady() {
             if (!ignoreall)
                 //(this->*process_packet)(_ringBuffer.tail());
                 alps_parse_hw_state(_ringBuffer.tail(), f);
-            //(this->*process_packet)(packet);
-            // if (!ignoreall)
-            //     alps_parse_hw_state(_ringBuffer.tail());
         } else {
             IOLog("ALPS: an invalid or bare packet has been dropped...\n");
             /* Might need to perform a full HW reset here if we keep receiving bad packets (consecutively) */

--- a/VoodooPS2Trackpad/alps.cpp
+++ b/VoodooPS2Trackpad/alps.cpp
@@ -3293,14 +3293,11 @@ void ALPS::setTouchPadEnable(bool enable) {
 }
 
 void ALPS::packetReady() {
-    struct alps_fields f;
     // empty the ring buffer, dispatching each packet...
     while (_ringBuffer.count() >= priv.pktsize) {
-        //UInt8 *packet = _ringBuffer.tail();
         if (priv.PSMOUSE_BAD_DATA == false) {
             if (!ignoreall)
-                //(this->*process_packet)(_ringBuffer.tail());
-                alps_parse_hw_state(_ringBuffer.tail(), f);
+                (this->*process_packet)(_ringBuffer.tail());
         } else {
             IOLog("ALPS: an invalid or bare packet has been dropped...\n");
             /* Might need to perform a full HW reset here if we keep receiving bad packets (consecutively) */

--- a/VoodooPS2Trackpad/alps.cpp
+++ b/VoodooPS2Trackpad/alps.cpp
@@ -1481,7 +1481,7 @@ void ALPS::alps_process_trackstick_packet_v7(UInt8 *packet)
 void ALPS::alps_process_touchpad_packet_v7(UInt8 *packet){
     struct alps_fields f;
     
-    //alps_parse_hw_state(_ringBuffer.tail(), f);
+    alps_parse_hw_state(_ringBuffer.tail(), f);
 }
 
 void ALPS::alps_process_packet_v7(UInt8 *packet){

--- a/VoodooPS2Trackpad/alps.cpp
+++ b/VoodooPS2Trackpad/alps.cpp
@@ -3390,30 +3390,33 @@ void ALPS::alps_parse_hw_state(const UInt8 buf[], struct alps_fields &f)
     if (ignoreall)
         return;
     
-    UInt8 *packet = _ringBuffer.tail();
     // get fingercounts from packets
     int fingers = 0;
-    //struct alps_fields f;
     
-    memset(&f, 0, sizeof(alps_fields));
-    
-    (this->alps_decode_packet_v7)(&f, packet);
-    
-    /* Reverse y co-ordinates to have 0 at bottom for gestures to work */
-    f.mt[0].y = priv.y_max - f.mt[0].y;
-    f.mt[1].y = priv.y_max - f.mt[1].y;
-    
-    // scale x & y to the axis which has the most resolution
-    if (xupmm < yupmm) {
-        f.mt[0].x = f.mt[0].x * yupmm / xupmm;
-    } else if (xupmm > yupmm) {
-        f.mt[0].y = f.mt[0].y * xupmm / yupmm;
+    if(priv.proto_version == ALPS_PROTO_V7) {
+        UInt8 *packet = _ringBuffer.tail();
+        
+        //struct alps_fields f;
+        
+        memset(&f, 0, sizeof(alps_fields));
+        
+        (this->alps_decode_packet_v7)(&f, packet);
+        
+        /* Reverse y co-ordinates to have 0 at bottom for gestures to work */
+        f.mt[0].y = priv.y_max - f.mt[0].y;
+        f.mt[1].y = priv.y_max - f.mt[1].y;
+        
+        // scale x & y to the axis which has the most resolution
+        if (xupmm < yupmm) {
+            f.mt[0].x = f.mt[0].x * yupmm / xupmm;
+        } else if (xupmm > yupmm) {
+            f.mt[0].y = f.mt[0].y * xupmm / yupmm;
+        }
+        
+        /* Dr Hurt: Scale all touchpads' axes to 6000 to be able to the same divisors for all models */
+        f.mt[0].x *= (6000 / ((priv.x_max + priv.y_max)/2));
+        f.mt[1].y *= (6000 / ((priv.x_max + priv.y_max)/2));
     }
-    
-    /* Dr Hurt: Scale all touchpads' axes to 6000 to be able to the same divisors for all models */
-    f.mt[0].x *= (6000 / ((priv.x_max + priv.y_max)/2));
-    f.mt[1].y *= (6000 / ((priv.x_max + priv.y_max)/2));
-    
     
     fingers = f.fingers;
     

--- a/VoodooPS2Trackpad/alps.cpp
+++ b/VoodooPS2Trackpad/alps.cpp
@@ -1481,27 +1481,6 @@ void ALPS::alps_process_trackstick_packet_v7(UInt8 *packet)
 void ALPS::alps_process_touchpad_packet_v7(UInt8 *packet){
     struct alps_fields f;
     
-    memset(&f, 0, sizeof(alps_fields));
-    
-    if (!(this->*decode_fields)(&f, packet))
-        return;
-    
-    /* Reverse y co-ordinates to have 0 at bottom for gestures to work */
-    f.mt[0].y = priv.y_max - f.mt[0].y;
-    f.mt[1].y = priv.y_max - f.mt[1].y;
-    
-    // TODO: maybe move this to alps_parse_hw_state
-    // scale x & y to the axis which has the most resolution
-    if (xupmm < yupmm) {
-        f.mt[0].x = f.mt[0].x * yupmm / xupmm;
-    } else if (xupmm > yupmm) {
-        f.mt[0].y = f.mt[0].y * xupmm / yupmm;
-    }
-    
-    /* Dr Hurt: Scale all touchpads' axes to 6000 to be able to the same divisors for all models */
-    f.mt[0].x *= (6000 / ((priv.x_max + priv.y_max)/2));
-    f.mt[1].y *= (6000 / ((priv.x_max + priv.y_max)/2));
-    
     //alps_parse_hw_state(_ringBuffer.tail(), f);
 }
 


### PR DESCRIPTION
This pull request fixes the annoying 2 finger jumping on V7 which could lead to random zooming out in Safari or very unstable zooming and rotation in Maps. This needs more investigation as now it only works on V7.

This is the current version:

https://user-images.githubusercontent.com/28839925/139529855-e9a8e59a-b84f-4411-ad73-b59510fbb496.mov

Here is the fixed version:

https://user-images.githubusercontent.com/28839925/139529890-d1ac58f9-837d-4e1f-8a01-ee20a5713b8c.mov


