### PR TITLE
Add option to revert new Caps Lock fix

### DIFF
--- a/Docs/ACPI/SSDT-Rev-CapsLock.dsl
+++ b/Docs/ACPI/SSDT-Rev-CapsLock.dsl
@@ -1,0 +1,17 @@
+// Revert Caps Lock Fix which was introduced here:
+// https://github.com/acidanthera/VoodooPS2/commit/7a4d7fb4867aa9b70a7b014912a87039b5338a40
+// Only use if Caps Lock is working inconsistently
+
+DefinitionBlock ("", "SSDT", 2, "SRHD", "ps2", 0)
+{
+    External (_SB_.PCI0.LPCB.PS2K, DeviceObj)
+    
+    Name(_SB.PCI0.LPCB.PS2K.RMCF, Package()
+    {
+        "Keyboard", Package()
+        {
+            "CapsLockFix", ">y",
+        },
+    })
+}
+//EOF

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -50,6 +50,7 @@
 #define kFunctionKeysStandard               "Function Keys Standard"
 #define kFunctionKeysSpecial                "Function Keys Special"
 #define kRemapPrntScr                       "RemapPrntScr"
+#define kCapsLockFix                        "CapsLockFix"
 #define kNumLockSupport                     "NumLockSupport"
 #define kNumLockOnAtBoot                    "NumLockOnAtBoot"
 #define kSwapCapsLockLeftControl            "Swap capslock and left control"
@@ -167,6 +168,7 @@ bool ApplePS2Keyboard::init(OSDictionary * dict)
     _lastdata = 0;
     
     _remapPrntScr = false;
+    _CapsLockFix = false;
     _numLockSupport = false;
     _numLockOnAtBoot = false;
     _swapcommandoption = false;
@@ -755,6 +757,12 @@ void ApplePS2Keyboard::setParamPropertiesGated(OSDictionary * dict)
     {
         _remapPrntScr = xml->getValue();
         setProperty(kRemapPrntScr, _remapPrntScr);
+    }
+    
+    if ((xml = OSDynamicCast(OSBoolean, dict->getObject(kCapsLockFix))))
+    {
+        _CapsLockFix = xml->getValue();
+        setProperty(kCapsLockFix, _CapsLockFix);
     }
     
     if ((xml = OSDynamicCast(OSBoolean, dict->getObject(kNumLockSupport))))
@@ -1810,7 +1818,7 @@ bool ApplePS2Keyboard::dispatchKeyboardEventWithPacket(const UInt8* packet)
             clock_get_uptime(&now_abs);
             dispatchKeyboardEventX(adbKeyCode, false, now_abs);
         }
-        if (goingDown && version_major < 18) {
+        if (goingDown && (version_major < 18 || _CapsLockFix)) {
             static bool firsttime = true;
             if (!firsttime)
             {

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -99,6 +99,7 @@ private:
     UInt32                      _f12ejectdelay;
     enum { kTimerSleep, kTimerEject } _timerFunc;
     bool                        _remapPrntScr;
+    bool                        _CapsLockFix;
     bool                        _numLockSupport;
     bool                        _numLockOnAtBoot;
     


### PR DESCRIPTION
This PR adds the ability to revert the new Caps Lock fix done in the [acidanthera repo](https://github.com/acidanthera/VoodooPS2/commit/7a4d7fb4867aa9b70a7b014912a87039b5338a40).

The new caps lock workaround is somehow broken on my laptop as it works every 4 taps, so I added the old workaround. The old workaround can be enabled by using the SSDT uploaded in the branch.

TBD:
- [ ] find a better name